### PR TITLE
Update of eth-utils to 1.0.3. in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 web3 == 3.16.4
-eth-utils == 0.7.1
+eth-utils == 1.0.3
 eth-testrpc == 1.3.0
 jsonnet == 0.9.5
 retry == 0.9.2


### PR DESCRIPTION
Fixes the following warning message:
rlp 1.0.1 has requirement eth-utils<2,>=1.0.2, but you'll have eth-utils 0.7.1 which is incompatible.
eth-tester 0.1.0b25 has requirement eth-utils<2.0.0,>=1.0.1, but you'll have eth-utils 0.7.1 which is incompatible.
eth-keys 0.2.0b3 has requirement eth-utils<2.0.0,>=1.0.0-beta.2, but you'll have eth-utils 0.7.1 which is incompatible.
eth-keyfile 0.5.1 has requirement eth-utils<2.0.0,>=1.0.0-beta.1, but you'll have eth-utils 0.7.1 which is incompatible.
eth-abi 1.1.1 has requirement eth-utils<2.0.0,>=1.0.1, but you'll have eth-utils 0.7.1 which is incompatible.
Installing collected packages: eth-utils
  Found existing installation: eth-utils 1.0.3
    Uninstalling eth-utils-1.0.3:
      Successfully uninstalled eth-utils-1.0.3
Successfully installed eth-utils-0.7.1