### PR TITLE
Update Bittrex market maker keeper to use updated api v3

### DIFF
--- a/market_maker_keeper/order_book.py
+++ b/market_maker_keeper/order_book.py
@@ -302,6 +302,7 @@ class OrderBookManager:
             orders = self.get_order_book().orders
 
             if len(orders) == 0:
+                self.logger.info(f"No open orders on order book.")
                 break
 
             self.logger.info(f"Cancelling {len(orders)} open orders...")


### PR DESCRIPTION
TODO:
- [x] Update `pyexchange` after [PR#16](https://github.com/makerdao/pyexchange/pull/161) is merged