### PR TITLE
pass expected parameters to GasPriceFactory.create_gas_price

### DIFF
--- a/market_maker_keeper/ddex_market_maker_keeper.py
+++ b/market_maker_keeper/ddex_market_maker_keeper.py
@@ -144,7 +144,7 @@ class DdexMarketMakerKeeper:
         self.bands_config = ReloadableConfig(self.arguments.config)
         self.price_max_decimals = None
         self.amount_max_decimals = None
-        self.gas_price = GasPriceFactory().create_gas_price(self.arguments)
+        self.gas_price = GasPriceFactory().create_gas_price(self.web3, self.arguments)
         self.price_feed = PriceFeedFactory().create_price_feed(self.arguments)
         self.spread_feed = create_spread_feed(self.arguments)
         self.control_feed = create_control_feed(self.arguments)

--- a/market_maker_keeper/etherdelta_market_maker_keeper.py
+++ b/market_maker_keeper/etherdelta_market_maker_keeper.py
@@ -167,7 +167,7 @@ class EtherDeltaMarketMakerKeeper:
         self.gem = ERC20Token(web3=self.web3, address=self.tub.gem())
 
         self.bands_config = ReloadableConfig(self.arguments.config)
-        self.eth_reserve = Wad.from_number(self.arguments.eth_reserve)
+        self.eth_reserve = Wad.from_number(self.web3, self.arguments.eth_reserve)
         self.min_eth_balance = Wad.from_number(self.arguments.min_eth_balance)
         self.min_eth_deposit = Wad.from_number(self.arguments.min_eth_deposit)
         self.min_sai_deposit = Wad.from_number(self.arguments.min_sai_deposit)

--- a/market_maker_keeper/idex_market_maker_keeper.py
+++ b/market_maker_keeper/idex_market_maker_keeper.py
@@ -148,7 +148,7 @@ class IdexMarketMakerKeeper:
         self.min_eth_balance = Wad.from_number(self.arguments.min_eth_balance)
         self.min_eth_deposit = Wad.from_number(self.arguments.min_eth_deposit)
         self.min_sai_deposit = Wad.from_number(self.arguments.min_sai_deposit)
-        self.gas_price = GasPriceFactory().create_gas_price(self.arguments)
+        self.gas_price = GasPriceFactory().create_gas_price(self.web3, self.arguments)
         self.price_feed = PriceFeedFactory().create_price_feed(self.arguments, self.tub)
         self.spread_feed = create_spread_feed(self.arguments)
         self.control_feed = create_control_feed(self.arguments)

--- a/market_maker_keeper/mpx_market_maker_keeper.py
+++ b/market_maker_keeper/mpx_market_maker_keeper.py
@@ -141,7 +141,7 @@ class MpxMarketMakerKeeper:
 
         self.bands_config = ReloadableConfig(self.arguments.config)
         self.price_max_decimals = None
-        self.gas_price = GasPriceFactory().create_gas_price(self.arguments)
+        self.gas_price = GasPriceFactory().create_gas_price(self.web3, self.arguments)
         self.price_feed = PriceFeedFactory().create_price_feed(self.arguments)
         self.spread_feed = create_spread_feed(self.arguments)
         self.control_feed = create_control_feed(self.arguments)

--- a/market_maker_keeper/oasis_market_maker_keeper.py
+++ b/market_maker_keeper/oasis_market_maker_keeper.py
@@ -163,7 +163,7 @@ class OasisMarketMakerKeeper:
         self.sell_token = Token(name=self.arguments.sell_token_name, address=Address(self.arguments.sell_token_address), decimals=self.arguments.sell_token_decimals)
         self.min_eth_balance = Wad.from_number(self.arguments.min_eth_balance)
         self.bands_config = ReloadableConfig(self.arguments.config)
-        self.gas_price = GasPriceFactory().create_gas_price(self.arguments)
+        self.gas_price = GasPriceFactory().create_gas_price(self.web3, self.arguments)
         self.price_feed = PriceFeedFactory().create_price_feed(self.arguments, tub)
         self.spread_feed = create_spread_feed(self.arguments)
         self.control_feed = create_control_feed(self.arguments)

--- a/market_maker_keeper/paradex_market_maker_keeper.py
+++ b/market_maker_keeper/paradex_market_maker_keeper.py
@@ -146,7 +146,7 @@ class ParadexMarketMakerKeeper:
         self.bands_config = ReloadableConfig(self.arguments.config)
         self.price_max_decimals = None
         self.amount_max_decimals = None
-        self.gas_price = GasPriceFactory().create_gas_price(self.arguments)
+        self.gas_price = GasPriceFactory().create_gas_price(self.web3, self.arguments)
         self.price_feed = PriceFeedFactory().create_price_feed(self.arguments)
         self.spread_feed = create_spread_feed(self.arguments)
         self.control_feed = create_control_feed(self.arguments)

--- a/market_maker_keeper/tethfinex_market_maker_keeper.py
+++ b/market_maker_keeper/tethfinex_market_maker_keeper.py
@@ -139,7 +139,7 @@ class TethfinexMarketMakerKeeper:
         self.price_feed = PriceFeedFactory().create_price_feed(self.arguments, tub)
 
         self.bands_config = ReloadableConfig(self.arguments.config)
-        self.gas_price = GasPriceFactory().create_gas_price(self.arguments)
+        self.gas_price = GasPriceFactory().create_gas_price(self.web3, self.arguments)
         self.spread_feed = create_spread_feed(self.arguments)
         self.control_feed = create_control_feed(self.arguments)
         self.order_history_reporter = create_order_history_reporter(self.arguments)

--- a/market_maker_keeper/theocean_market_maker_keeper.py
+++ b/market_maker_keeper/theocean_market_maker_keeper.py
@@ -140,7 +140,7 @@ class TheOceanMarketMakerKeeper:
         self.pair = Pair(self.token_sell.address, self.token_buy.address)
         self.bands_config = ReloadableConfig(self.arguments.config)
         self.price_max_decimals = None
-        self.gas_price = GasPriceFactory().create_gas_price(self.arguments)
+        self.gas_price = GasPriceFactory().create_gas_price(self.web3, self.arguments)
         self.price_feed = PriceFeedFactory().create_price_feed(self.arguments)
         self.spread_feed = create_spread_feed(self.arguments)
         self.control_feed = create_control_feed(self.arguments)

--- a/market_maker_keeper/zrx_market_maker_keeper.py
+++ b/market_maker_keeper/zrx_market_maker_keeper.py
@@ -158,7 +158,7 @@ class ZrxMarketMakerKeeper:
 
         self.min_eth_balance = Wad.from_number(self.arguments.min_eth_balance)
         self.bands_config = ReloadableConfig(self.arguments.config)
-        self.gas_price = GasPriceFactory().create_gas_price(self.arguments)
+        self.gas_price = GasPriceFactory().create_gas_price(self.web3, self.arguments)
         self.price_feed = PriceFeedFactory().create_price_feed(self.arguments)
         self.spread_feed = create_spread_feed(self.arguments)
         self.control_feed = create_control_feed(self.arguments)


### PR DESCRIPTION
Looks like only uniswap was updated to pass `web3` instance to the factory; I added the others.  ~(Note there are some seemingly-unrelated unit test issues.)~ Unit test issues were a problem with my own virtualenv.