### PR TITLE
bring --endpoint-uri support to oasis

### DIFF
--- a/market_maker_keeper/oasis_market_maker_cancel.py
+++ b/market_maker_keeper/oasis_market_maker_cancel.py
@@ -33,8 +33,8 @@ class OasisMarketMakerCancel:
 
     def __init__(self, args: list, **kwargs):
         parser = argparse.ArgumentParser(prog='oasis-market-maker-cancel')
-        parser.add_argument("--endpoint-uri", type=str, default="http://localhost:8545",
-                            help="JSON-RPC uri (default: `http://localhost:8545`)")
+        parser.add_argument("--endpoint-uri", type=str,
+                            help="JSON-RPC uri (example: `http://localhost:8545`)")
         parser.add_argument("--rpc-host", default="localhost", type=str, help="[DEPRECATED] JSON-RPC host (default: `localhost')")
         parser.add_argument("--rpc-port", default=8545, type=int, help="[DEPRECATED] JSON-RPC port (default: `8545')")
         parser.add_argument("--rpc-timeout", help="JSON-RPC timeout (in seconds, default: 10)", default=10, type=int)

--- a/market_maker_keeper/oasis_market_maker_cancel.py
+++ b/market_maker_keeper/oasis_market_maker_cancel.py
@@ -21,7 +21,7 @@ import sys
 
 from web3 import Web3, HTTPProvider
 
-from pymaker import Address
+from pymaker import Address, web3_via_http
 from pymaker.gas import FixedGasPrice, DefaultGasPrice
 from pymaker.keys import register_keys
 from pymaker.oasis import MatchingMarket
@@ -33,8 +33,10 @@ class OasisMarketMakerCancel:
 
     def __init__(self, args: list, **kwargs):
         parser = argparse.ArgumentParser(prog='oasis-market-maker-cancel')
-        parser.add_argument("--rpc-host", help="JSON-RPC host (default: `localhost')", default="localhost", type=str)
-        parser.add_argument("--rpc-port", help="JSON-RPC port (default: `8545')", default=8545, type=int)
+        parser.add_argument("--endpoint-uri", type=str, default="http://localhost:8545",
+                            help="JSON-RPC uri (default: `http://localhost:8545`)")
+        parser.add_argument("--rpc-host", default="localhost", type=str, help="[DEPRECATED] JSON-RPC host (default: `localhost')")
+        parser.add_argument("--rpc-port", default=8545, type=int, help="[DEPRECATED] JSON-RPC port (default: `8545')")
         parser.add_argument("--rpc-timeout", help="JSON-RPC timeout (in seconds, default: 10)", default=10, type=int)
         parser.add_argument("--eth-from", help="Ethereum account from which to send transactions", required=True, type=str)
         parser.add_argument("--eth-key", type=str, nargs='*', help="Ethereum private key(s) to use")
@@ -42,8 +44,14 @@ class OasisMarketMakerCancel:
         parser.add_argument("--gas-price", help="Gas price in Wei (default: node default)", default=0, type=int)
         self.arguments = parser.parse_args(args)
 
-        self.web3 = kwargs['web3'] if 'web3' in kwargs else Web3(HTTPProvider(endpoint_uri=f"http://{self.arguments.rpc_host}:{self.arguments.rpc_port}",
-                                                                              request_kwargs={"timeout": self.arguments.rpc_timeout}))
+        if 'web3' in kwargs:
+            self.web3 = kwargs['web3']
+        elif self.arguments.endpoint_uri:
+            self.web3: Web3 = web3_via_http(self.arguments.endpoint_uri, self.arguments.rpc_timeout)
+        else:
+            self.web3 = Web3(HTTPProvider(endpoint_uri=f"http://{self.arguments.rpc_host}:{self.arguments.rpc_port}",
+                                          request_kwargs={"timeout": self.arguments.rpc_timeout}))
+
         self.web3.eth.defaultAccount = self.arguments.eth_from
         self.our_address = Address(self.arguments.eth_from)
         register_keys(self.web3, self.arguments.eth_key)

--- a/market_maker_keeper/oasis_market_maker_keeper.py
+++ b/market_maker_keeper/oasis_market_maker_keeper.py
@@ -52,8 +52,8 @@ class OasisMarketMakerKeeper:
     def __init__(self, args: list, **kwargs):
         parser = argparse.ArgumentParser(prog='oasis-market-maker-keeper')
 
-        parser.add_argument("--endpoint-uri", type=str, default="http://localhost:8545",
-                            help="JSON-RPC uri (default: `http://localhost:8545`)")
+        parser.add_argument("--endpoint-uri", type=str,
+                            help="JSON-RPC uri (example: `http://localhost:8545`)")
 
         parser.add_argument("--rpc-host", default="localhost", type=str,
                             help="[DEPRECATED] JSON-RPC host (default: `localhost')")

--- a/market_maker_keeper/util.py
+++ b/market_maker_keeper/util.py
@@ -25,6 +25,8 @@ def setup_logging(arguments):
                         level=(logging.DEBUG if arguments.debug else logging.INFO))
     logging.getLogger('urllib3.connectionpool').setLevel(logging.INFO)
     logging.getLogger('requests.packages.urllib3.connectionpool').setLevel(logging.INFO)
+    logging.getLogger("web3").setLevel(logging.INFO)
+    logging.getLogger("requests").setLevel(logging.INFO)
 
 
 def sanitize_url(url):

--- a/market_maker_keeper/util.py
+++ b/market_maker_keeper/util.py
@@ -24,9 +24,8 @@ def setup_logging(arguments):
     logging.basicConfig(format='%(asctime)-15s %(levelname)-8s %(message)s',
                         level=(logging.DEBUG if arguments.debug else logging.INFO))
     logging.getLogger('urllib3.connectionpool').setLevel(logging.INFO)
-    logging.getLogger('requests.packages.urllib3.connectionpool').setLevel(logging.INFO)
-    logging.getLogger("web3").setLevel(logging.INFO)
     logging.getLogger("requests").setLevel(logging.INFO)
+    logging.getLogger("web3").setLevel(logging.INFO)
 
 
 def sanitize_url(url):


### PR DESCRIPTION
Most DEXes cannot be configured to use HTTPS or a third-party node provider because configuration parameters restrict the caller by building the URI in code.  Uniswapv2 is the exception, as it was introduced with `--endpoint-uri` from inception.  Since we don't wish to break older configs, I've updated Oasis to support `--endpoint-uri`, falling back to `--rpc-host` and `--rpc-port` if not specified.

`pymaker` has been updated with improved support for nonce determination on _quiknode_ and _infura_ endpoints.

Logspew has been further reduced when running in `--debug` mode.